### PR TITLE
preventDefault on enter key

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -282,6 +282,7 @@
             if (self.options.freeInput) {
               self.add($input.val());
               $input.val('');
+              event.preventDefault();
             }
             break;
 


### PR DESCRIPTION
If the tagsinput is within a form, the form submits when you try to accept a typeahead value with enter. Not sure if this should only happen when freeInput is enabled
