### PR TITLE
Use typeahead.js instead of bootstrap's built in typeahead component

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -242,6 +242,8 @@
             break;
           // ENTER
           case 13:
+          // TAB
+          case 9:
             if (self.options.freeInput) {
               self.add($input.val());
               $input.val('');


### PR DESCRIPTION
Hi, two things here.
First, move to typeahed.js. It's something I sketeched and works for me, but had not been throughly tested.

Second - a little unrelated to that, but i thought it was a good usability improvement - add TAB to the tag completion keys, so you can hit either enter or tab to complete a tag. 

HTH in moving over to bootstrap 3, or just in general. This does require usage of typeahead.js, which is an independent library. 
