### PR TITLE
Avoid conflict with other selects when checking for value presence

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -85,7 +85,7 @@
       $tag.after(' ');
 
       // add <option /> if item represents a value not present in one of the <select />'s options
-      if (self.isSelect && !$('option[value="' + escape(itemValue) + '"]')[0]) {
+      if (self.isSelect && !$('option[value="' + escape(itemValue) + '"]',self.$element)[0]) {
         var $option = $('<option selected>' + htmlEncode(itemText) + '</option>');
         $option.data('item', item);
         $option.attr('value', itemValue);


### PR DESCRIPTION
The check in line 88 for an <option /> tag with the same value being added can potentially result in a false positive if there is another <select/> element on the page with the same value on an option. Adding the context to the jquery expression seems to fix it.
