### PR TITLE
Fix example for BS3 "Objects as tags"

### DIFF
--- a/examples/bootstrap3/index.html
+++ b/examples/bootstrap3/index.html
@@ -204,15 +204,6 @@ $('input').tagsinput('input').typeahead({
                   <pre class="prettyprint linenums">&lt;input type=&quot;text&quot; /&gt;
 &lt;script&gt;
 $('input').tagsinput({
-  tagClass: function(item) {
-    switch (item.continent) {
-      case 'Europe'   : return 'label label-primary';
-      case 'America'  : return 'label label-danger label-important';
-      case 'Australia': return 'label label-success';
-      case 'Africa'   : return 'label label-default';
-      case 'Asia'     : return 'label label-warning';
-    }
-  },
   itemValue: 'value',
   itemText: 'text'
 });
@@ -222,15 +213,15 @@ $('input').tagsinput('add', { "value": 7 , "text": "Sydney"      , "continent": 
 $('input').tagsinput('add', { "value": 10, "text": "Beijing"     , "continent": "Asia"      });
 $('input').tagsinput('add', { "value": 13, "text": "Cairo"       , "continent": "Africa"    });
 
-// Adding custom typeahead support using http://twitter.github.io/typeahead.js
 $('input').tagsinput('input').typeahead({
   valueKey: 'text',
-  prefetch: 'cities.json',
+  prefetch: 'assets/cities.json',
   template: '&lt;p&gt;{{text}}&lt;/p&gt;',
   engine: Hogan
-}).bind('typeahead:selected', $.proxy(function (obj, datum) {  
-  this.tagsinput('add', datum);
-  this.tagsinput('input').typeahead('setQuery', '');
+
+}).bind('typeahead:selected', $.proxy(function (obj, datum) {
+	this.tagsinput('add', datum);
+	this.tagsinput('input').typeahead('setQuery', '');
 }, $('input')));
 &lt;/script&gt;</pre>
                 </div>


### PR DESCRIPTION
The current "Objects as tags" example for Bootstrap 3 is wrong. It is the example for the next item, "Categorizing tags". This patch fixes the problem by putting in the correct example. It is copied from the app_bs3.js file on the page and modified to fit the style of the other examples.
