### PR TITLE
Added a bower.json file to integrate within bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "bootstrap-tagsinput",
+  "version": "0.3.7",
+  "homepage": "https://github.com/TimSchlechter/bootstrap-tagsinput",
+  "authors": [
+    "Tim Schlechter"
+  ],
+  "description": "jQuery plugin providing a Twitter Bootstrap user interface for managing tags.",
+  "main": "dist/bootstrap-tagsinput.min.js",
+  "keywords": [
+    "tags",
+    "bootstrap",
+    "input",
+    "select",
+    "form"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
It would be nice to get bootstrap tagsinput in our project by jjust performing a simple `bower install bootstrap-tagsinput`
That's why I've just added the bower.json file
After that, you'll just have to register it in the bower registery
