### PR TITLE
added .css to main[] in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Tim Schlechter"
   ],
   "description": "jQuery plugin providing a Twitter Bootstrap user interface for managing tags.",
-  "main": "dist/bootstrap-tagsinput.min.js",
+  "main": [
+    "dist/bootstrap-tagsinput.min.js",
+    "dist/bootstrap-tagsinput.css"
+  ],
   "keywords": [
     "tags",
     "bootstrap",


### PR DESCRIPTION
bootstrap-tagsinput.css should probably also be in bower.json, in order to be automatically included when running things like brunch.io
