### PR TITLE
Changed display property of .tag

### DIFF
--- a/dist/bootstrap-tagsinput.less
+++ b/dist/bootstrap-tagsinput.less
@@ -30,6 +30,7 @@
   .tag {
     margin-right: 2px;
     color: white;
+    display:inline-block;
 
     [data-role="remove"] {
       margin-left:8px;


### PR DESCRIPTION
Setting to .inline-block prevents a single tag from breaking onto 2 lines when the container width is at a certain width.
