### PR TITLE
Fixed maxTags enabled bug

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -170,8 +170,6 @@
 
       self.pushVal();
 
-      if (self.options.maxTags && !this.isEnabled())
-        this.enable();
     },
 
     /**


### PR DESCRIPTION
Removed some lines that appear to be deprecated code. These lines crash execution when calling 'removeAll' method with options.maxTags set. 
