### PR TITLE
Fixed bug when removing items

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -143,7 +143,8 @@
       if (item) {
         $('.tag', self.$container).filter(function() { return $(this).data('item') === item; }).remove();
         $('option', self.$element).filter(function() { return $(this).data('item') === item; }).remove();
-        self.itemsArray.splice($.inArray(item, self.itemsArray), 1);
+        if($.inArray(item, self.itemsArray) !== -1)
+          self.itemsArray.splice($.inArray(item, self.itemsArray), 1);
       }
 
       if (!dontPushVal)


### PR DESCRIPTION
Found this bug:

Say you have the array ['Yes', 'No']

Calling tagsinput('remove', 'Maybe') would cause an element to be removed, although no match was found. This is because $.inArray returns -1 if the item isn't found, and we then splice between -1 and 1.
