### PR TITLE
Fix uncaught exception trying to reinitialize tagsinput object

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -430,10 +430,16 @@
         // Init tags from $(this).val()
         $(this).val($(this).val());
       } else {
-        // Invoke function on existing tags input
-        var retVal = tagsinput[arg1](arg2);
-        if (retVal !== undefined)
-          results.push(retVal);
+        // tagsinput already exists
+        if (!arg1 && !arg2)
+          // no function, trying to init
+          results.push(tagsinput);
+        else {
+          // Invoke function on existing tags input
+          var retVal = tagsinput[arg1](arg2);
+          if (retVal !== undefined)
+            results.push(retVal);
+        }
       }
     });
 

--- a/test/bootstrap-tagsinput/reproduced_bugs.tests.js
+++ b/test/bootstrap-tagsinput/reproduced_bugs.tests.js
@@ -100,6 +100,19 @@ describe("bootstrap-tagsinput", function() {
           });
         });
       });
+    });
+
+    describe("#90: Error in reinitialization (arg1 and arg2 are undefined)", function() {
+      describe("init tagsinput twice", function() {
+        testTagsInput('<input type="text" value="1" />', { itemValue: function(item) { return item.value; } }, function() {
+          it("should not fail if an element is reinitialized", function () {
+            this.$element.tagsinput();
+          });
+          it("should return the original instance if already initialized", function () {
+            return this.$element.tagsinput() === this;
+          });
+        });
+      });
     })
   });
 });


### PR DESCRIPTION
Related https://github.com/TimSchlechter/bootstrap-tagsinput/pull/90

Fixes an issue when a tagsinput is reinitialized. Also added tests to confirm.
