### PR TITLE
Add Before Item Added event

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -98,6 +98,13 @@
         }
         return;
       }
+      var beforeItemAddedEvent = $.Event('beforeItemAdded', { item: item });
+      self.$element.trigger(beforeItemAddedEvent);
+      
+      if(beforeItemAddedEvent.isDefaultPrevented()){
+        return false;
+      }
+      
 
       // register item in internal array and map
       self.itemsArray.push(item);
@@ -338,9 +345,10 @@
             // When key corresponds one of the confirmKeys, add current input
             // as a new tag
             if (self.options.freeInput && $.inArray(event.which, self.options.confirmKeys) >= 0) {
-              self.add($input.val());
-              $input.val('');
-              event.preventDefault();
+              if(self.add($input.val()) !== false){
+                $input.val('');
+                event.preventDefault();
+              }
             }
         }
 


### PR DESCRIPTION
added a hook for just before the item is added so a developer could do an arbitrary check if they want to accept the value. If a dev wants to decide if the value should to be added, they can create an event handler for 'beforeItemAdded' and inside that handler either return false or call event.preventDefault when they wish not to have the item added. The text will also not be cleared from the input box.
