### PR TITLE
Make it possible to pass arguments to the typeahead library

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -210,7 +210,7 @@
 
     /**
      * Assembly value by retrieving the value of each item, and set it on the
-     * element. 
+     * element.
      */
     pushVal: function() {
       var self = this,
@@ -245,7 +245,7 @@
       if (typeahead.source && $.fn.typeahead) {
         makeOptionFunction(typeahead, 'source');
 
-        self.$input.typeahead({
+        self.$input.typeahead($.extend({}, typeahead, {
           source: function (query, process) {
             function processItems(items) {
               var texts = [];
@@ -284,7 +284,7 @@
             var regex = new RegExp( '(' + this.query + ')', 'gi' );
             return text.replace( regex, "<strong>$1</strong>" );
           }
-        });
+        }));
       }
 
       self.$container.on('click', $.proxy(function(event) {
@@ -381,7 +381,7 @@
     },
 
     /**
-     * Sets focus on the tagsinput 
+     * Sets focus on the tagsinput
      */
     focus: function() {
       this.$input.focus();
@@ -446,9 +446,9 @@
   };
 
   $.fn.tagsinput.Constructor = TagsInput;
-  
+
   /**
-   * Most options support both a string or number as well as a function as 
+   * Most options support both a string or number as well as a function as
    * option value. This function makes sure that the option with the given
    * key in the given options is wrapped in a function
    */


### PR DESCRIPTION
This little change allows us to pass arguments to the typeahead lib. For example, here is how you config Bootstrap 3 Typeahead (https://github.com/bassjobsen/Bootstrap-3-Typeahead):

``` javascript
$("input").tagsinput({
    freeInput: false,
    typeahead: {
      source: ["foo", "bar"],
      items: 10,
      showHintOnFocus: true,
      minLength: 0
    }
  })
```
