### PR TITLE
renamed `setQuery` to `val`

### DIFF
--- a/examples/bootstrap3/index.html
+++ b/examples/bootstrap3/index.html
@@ -174,7 +174,7 @@ $('input').tagsinput('input').typeahead({
   prefetch: 'citynames.json'
 }).bind('typeahead:selected', $.proxy(function (obj, datum) {  
   this.tagsinput('add', datum.value);
-  this.tagsinput('input').typeahead('setQuery', '');
+  this.tagsinput('input').typeahead('val', '');
 }, $('input')));
 &lt;/script&gt;</pre>
                 </div>
@@ -221,7 +221,7 @@ $('input').tagsinput('input').typeahead({
 
 }).bind('typeahead:selected', $.proxy(function (obj, datum) {
 	this.tagsinput('add', datum);
-	this.tagsinput('input').typeahead('setQuery', '');
+	this.tagsinput('input').typeahead('val', '');
 }, $('input')));
 &lt;/script&gt;</pre>
                 </div>
@@ -277,7 +277,7 @@ $('input').tagsinput('input').typeahead({
   engine: Hogan
 }).bind('typeahead:selected', $.proxy(function (obj, datum) {  
   this.tagsinput('add', datum);
-  this.tagsinput('input').typeahead('setQuery', '');
+  this.tagsinput('input').typeahead('val', '');
 }, $('input')));
 &lt;/script&gt;</pre>
                 </div>


### PR DESCRIPTION
Correct me if I'm wrong but I tried the examples and got stuck using the suggested `setQuery` method from typeahead.js to close the suggestion box. During my research I stumpled upon a stackoverflow question which pointed me to the right direction to use the `val` method which closes the suggestion box correctly.
