### PR TITLE
Custom classes for tags don't work if entered as strings

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -236,7 +236,7 @@
 
       makeOptionItemFunction(self.options, 'itemValue');
       makeOptionItemFunction(self.options, 'itemText');
-      makeOptionItemFunction(self.options, 'tagClass');
+      makeOptionFunction(self.options, 'tagClass');
 
       // for backwards compatibility, self.options.source is deprecated
       if (self.options.source)


### PR DESCRIPTION
tagClass option bug - turn a tagClass option string into a function that returns the string.
The following example in the documentation doesn't work:

$('input').tagsinput({
  tagClass: 'big'
});

Right now, you have to enter it as 
$('input').tagsinput({
  tagClass: function(x){return 'big';}
});
