### PR TITLE
the freeinput has to be out of the typeahead options 

### DIFF
--- a/examples/bootstrap3/index.html
+++ b/examples/bootstrap3/index.html
@@ -447,9 +447,9 @@ angular.module('AngularExample', ['bootstrap-tagsinput'])
                 </div>
                 <pre class="prettyprint linenums">$('input').tagsinput({
   typeahead: {
-    source: ['Amsterdam', 'Washington', 'Sydney', 'Beijing', 'Cairo'],
-    freeInput: true
-  }
+    source: ['Amsterdam', 'Washington', 'Sydney', 'Beijing', 'Cairo']
+  },
+  freeInput: true
 });</pre>
               </td>
             </tr>


### PR DESCRIPTION
this is a small fix in the documentation. 
the freeinput has to be out of the typeahead options in order to take effect.

Regards,
Marco
