### PR TITLE
Add compability for IE (input size issue)

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -35,10 +35,11 @@
     this.inputSize = Math.max(1, this.placeholderText.length);
 
     this.$container = $('<div class="bootstrap-tagsinput"></div>');
-    this.$input = $('<input size="' + this.inputSize + '" type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
+    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
 
     this.$element.after(this.$container);
 
+    this.$input.get(0).style.setProperty('width', this.inputSize < 3 ? 3 : this.inputSize + 'em', 'important'); // to override bootstrap width !important
     this.build(options);
   }
 
@@ -345,7 +346,7 @@
         }
 
         // Reset internal input's size
-        $input.attr('size', Math.max(this.inputSize, $input.val().length));
+        $input.get(0).style.setProperty('width', Math.max(this.inputSize < 3 ? 3 : this.inputSize, $input.val().length) + 'em', 'important');
       }, self));
 
       // Remove icon clicked


### PR DESCRIPTION
In IE (tested in IE 10-11, but I think that this issue will be occurred into older versions also) there are issue with attribute "size" of input.
IN some reasons, IE think that all fonts are monospaced, and set the size of input incorrect.
This commit are fix this behavior.
The rest of modern browsers are works well with both solutions.
