### PR TITLE
Add option for disabling adding items when input is blurred

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -12,6 +12,7 @@
       return this.itemValue(item);
     },
     freeInput: true,
+    addOnBlur: true,
     maxTags: undefined,
     confirmKeys: [13],
     onTagExists: function(item, $tag) {
@@ -302,10 +303,13 @@
         self.$input.focus();
       }, self));
 
-        self.$input.on('focusout', $.proxy(function(event) {
-            self.add(self.$input.val());
-            self.$input.val('');
-        }, self));
+        if (self.options.addOnBlur) {
+          self.$input.on('focusout', $.proxy(function(event) {
+              self.add(self.$input.val());
+              self.$input.val('');
+          }, self));
+        }
+        
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {
         var $input = $(event.target),


### PR DESCRIPTION
In f72a0b3f4094350299f97cbc9561fbadec4589df, a new behavior was introduced which adds items when the input is blurred. This isn't always desired, so I added an option to disable this functionality.

This also fixes #169.
