### PR TITLE
style updates respecting Bootstrap defaults

### DIFF
--- a/src/bootstrap-tagsinput.css
+++ b/src/bootstrap-tagsinput.css
@@ -16,10 +16,20 @@
   box-shadow: none;
   outline: none;
   background-color: transparent;
-  padding: 0;
+  padding: 0 6px;
   margin: 0;
   width: auto !important;
   max-width: inherit;
+}
+.bootstrap-tagsinput.form-control input::-moz-placeholder {
+  color: #777;
+  opacity: 1;
+}
+.bootstrap-tagsinput.form-control input:-ms-input-placeholder {
+  color: #777;
+}
+.bootstrap-tagsinput.form-control input::-webkit-input-placeholder {
+  color: #777;
 }
 .bootstrap-tagsinput input:focus {
   border: none;


### PR DESCRIPTION
Updated CSS to match Bootstrap defaults:
- closes #195: remove margin-bottom from .bootstrap-tagsinput
- closes #199: match input.form-control padding and placeholder color

before:
![image](https://cloud.githubusercontent.com/assets/906846/3884965/8ec9649c-21b8-11e4-9963-612a197e6814.png)

after:
![image](https://cloud.githubusercontent.com/assets/906846/3884967/a1e85f1a-21b8-11e4-8150-3a07ca4ba8f6.png)
